### PR TITLE
merge: Feature/barchart/timeunit

### DIFF
--- a/src/features/barchart/Bar.js
+++ b/src/features/barchart/Bar.js
@@ -7,9 +7,9 @@ const StyledBar = styled.div`
     cursor: pointer;
     text-align: center;
     top: 0%;
-    left: ${(props) => props.start/props.cnt*10}%;
+    left: ${(props) => props.start/props.calculatedEndTime*100}%;
     height: 100%;
-    width: ${(props) => props.duration/props.cnt*10}%; 
+    width: ${(props) => props.duration/props.calculatedEndTime*100}%; 
     z-index: 1;
     background-color: ${(props) => props.backgroundColor};
 `;
@@ -22,15 +22,16 @@ class Bar extends Component {
         delete info["backgroundColor"]
         this.props.clickBar(info)
     }
-
+    
     render() {
         return (
             <StyledBar 
                 className="bar"
+                calculatedEndTime={this.props.calculatedEndTime}
+                digit={this.props.digit}
                 onClick={() => this.clickBar()} 
-                start={this.props.data.ts/1000} 
-                duration={this.props.data.dur/1000} 
-                cnt={this.props.cnt}
+                start={this.props.data.ts}
+                duration={this.props.data.dur}
                 name={this.props.data.name}
                 backgroundColor={this.props.data.backgroundColor}>
                 <div className="bar-title">{this.props.data.name}</div>

--- a/src/features/barchart/Board.js
+++ b/src/features/barchart/Board.js
@@ -26,8 +26,10 @@ class Board extends Component {
         selectedOP: null,
         fileName: null,
         data: null,
-        MaxEndTime: null,
+        calculatedEndTime: null,
         utility: null,
+        digit: null,
+        displayTimeUnit: null,
         colorList: ['aquamarine', 'cornflowerblue', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgreen', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightsteelblue', 'lime', 'limegreen', 'mediumaquamarine', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'mistyrose', 'olive', 'olivedrab', 'orange', 'orangered', 'orchid', 'palegreen', 'palevioletred', 'paleturquoise', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'thistle', 'yellowgreen', 'firebrick', 'dodgerblue', 'darkorange', 'crimson', 'darkmagenta']
     }
 
@@ -58,6 +60,7 @@ class Board extends Component {
         const reader = new FileReader();
         reader.onload = () => {
             const data = JSON.parse(reader.result).traceEvents
+            this.setState({displayTimeUnit: JSON.parse(reader.result).displayTimeUnit})
             this.processData(data)
         }
         reader.readAsText(file, /* optional */ "euc-kr");
@@ -101,14 +104,31 @@ class Board extends Component {
             utility[key] = Math.round(utility[key]*100 / MaxEndTime)/100
         })
         this.setState({utility: utility})
-        MaxEndTime = Math.ceil(MaxEndTime/10000)
-        this.setState({rulerCnt: MaxEndTime})
+
+        let MaxEndTime_ = MaxEndTime
+        let deci = 0
+        while (MaxEndTime_ > 0) {
+            MaxEndTime_ = parseInt(MaxEndTime_ / 10)
+            deci += 1
+        }
+        
+        this.setState({rulerCnt: Math.ceil(MaxEndTime/(10**(deci-1)))*(10**(deci-1))}) // MaxEndTime 올림한 수
+        this.setState({calculatedEndTime: Math.ceil(MaxEndTime/(10**(deci-1)))*(10**(deci-1))}) // MaxEndTime 올림한 수
+        this.setState({digit: deci}) // MaxEndTime의 자릿수
         this.setState({data: processedData})
     }
 
     renderLevel() {
         return Object.keys(this.state.data).map((key) => {
-            return  <Level processName={key} utility={this.state.utility[key]} data={this.state.data[key]} key={key} rulerCnt={this.state.rulerCnt} clickBar={this.clickBar}/>
+            return  <Level 
+                        calculatedEndTime={this.state.calculatedEndTime}
+                        digit={this.state.digit}
+                        processName={key}
+                        utility={this.state.utility[key]}
+                        data={this.state.data[key]}
+                        key={key}
+                        rulerCnt={this.state.rulerCnt}
+                        clickBar={this.clickBar}/>
         });
     }
 
@@ -123,7 +143,10 @@ class Board extends Component {
             <div className="board">
                 {this.state.data? 
                     <ZoomInOut ratio={this.state.ratio} className="content">
-                        <Ruler rulerCnt={this.state.rulerCnt}/>
+                        <Ruler
+                            calculatedEndTime={this.state.calculatedEndTime}
+                            digit={this.state.digit}
+                            rulerCnt={this.state.rulerCnt}/>
                         {this.renderLevel()}
                     </ZoomInOut>
                 : ''}
@@ -135,7 +158,7 @@ class Board extends Component {
                 <button onClick={() => this.handleRulerCntMultipleClick(2)}>Zoom In *2</button>
                 <button onClick={() => this.handleRulerCntMultipleClick(0.5)}>Zoom Out /2</button>
             </div>
-            <Detail selectedOP={this.state.selectedOP}/>
+            <Detail selectedOP={this.state.selectedOP} displayTimeUnit={this.state.displayTimeUnit}/>
         </div>
         );
     }

--- a/src/features/barchart/DataBar.js
+++ b/src/features/barchart/DataBar.js
@@ -15,15 +15,21 @@ const StyledBargraduation = styled.div`
 class DataBar extends Component {
     renderBar() {
         return this.props.data.map((ele) => {
-            return  <Bar clickBar={this.props.clickBar} data={ele} cnt={this.props.rulerCnt} key={`${ele.name}-${ele.ts}`}/>
+            return  <Bar 
+                        calculatedEndTime={this.props.calculatedEndTime}
+                        digit={this.props.digit}
+                        clickBar={this.props.clickBar}
+                        data={ele}
+                        key={`${ele.name}-${ele.ts}`}
+                        />
         });
     }
 
     render() {
         const mapToBarGraduation = () => {
             const result = [];
-            for(let i=0; i<this.props.rulerCnt; i++){
-                result.push(<StyledBargraduation i={i} cnt={this.props.rulerCnt} key={i}/>)
+            for(let i=0; i<parseInt(this.props.calculatedEndTime/(10**(this.props.digit-1))); i++){
+                result.push(<StyledBargraduation i={i} cnt={parseInt(this.props.calculatedEndTime/(10**(this.props.digit-1)))} key={i}/>)
             }
             return result
         }

--- a/src/features/barchart/Detail.js
+++ b/src/features/barchart/Detail.js
@@ -1,6 +1,10 @@
 import React, { Component } from 'react';
 
 class Detail extends Component {
+    state = {
+        timeUnit: {'ms': 10**(-3), 'us': 1, 'ns': 10**3}
+    }
+
     renderArgs(value){
         return Object.keys(value).map((key) => {
             return <div className="arg" key={key}>ㄴ{key} : {value[key]}</div>
@@ -12,6 +16,8 @@ class Detail extends Component {
             return Object.keys(this.props.selectedOP).map((key) => {
                 if (key === 'args') {
                     return  <div className="args" key={key}>{key} {this.renderArgs(this.props.selectedOP[key])}</div>
+                } else if (key === 'ts' || key === 'dur') {
+                    return  <div key={key}>{key} : {Math.round(this.props.selectedOP[key]*this.state.timeUnit[this.props.displayTimeUnit]*1000)/1000} {this.props.displayTimeUnit} </div>
                 } else {
                     return  <div key={key}>{key} : {this.props.selectedOP[key]}</div>
                 }

--- a/src/features/barchart/Level.js
+++ b/src/features/barchart/Level.js
@@ -18,7 +18,15 @@ class Level extends Component {
 
     renderDataBar() {
         return Object.keys(this.props.data).map((key) => {
-            return  <DataBar categoryName={key} data={this.props.data[key]} key={key} rulerCnt={this.props.rulerCnt} clickBar={this.props.clickBar}/>
+            return  <DataBar
+                        calculatedEndTime={this.props.calculatedEndTime}
+                        digit={this.props.digit}
+                        unit={this.props.unit}
+                        categoryName={key}
+                        data={this.props.data[key]}
+                        key={key}
+                        rulerCnt={this.props.rulerCnt}
+                        clickBar={this.props.clickBar}/>
         });
     }
 

--- a/src/features/barchart/Ruler.js
+++ b/src/features/barchart/Ruler.js
@@ -7,21 +7,37 @@ const StyledRulergraduation = styled.div`
     left: ${(props) => props.i/props.cnt*100}%;
     bottom: 0%;
     width: 0.5px;
-    height: ${(props) => props.i%10 === 0? 100 : 25}%;
+    height: 100%;
     background-color: var(--vscode-foreground);
     &:after {
-        content: '${(props) => props.i%10 === 0 && props.i<props.cnt ? props.i+'ms' : ''}';
+        content: '${(props) => props.graduation}';
         margin-left: 3px;
         font-size: 10px;
     }
 `;
 
 class Ruler extends Component {
+    calculateGraduation(graduation) {
+        if (graduation >= 1000) {
+            return graduation/1000 + 'ms'
+        } else if (graduation >= 1) {
+            return graduation + 'us'
+        } else if (graduation === 0) {
+            return 0
+        } else {
+            return graduation*1000 + 'ns'
+        }
+    }
+
     render() {
         const mapToRulergraduation = () => { // 줄자 눈금 반복 랜더링
             const result = [];
-            for(let i=0; i<this.props.rulerCnt*10+1; i++){
-                result.push(<StyledRulergraduation i={i} cnt={this.props.rulerCnt*10} key={i}/>)
+            for(let i=0; i<parseInt(this.props.calculatedEndTime/(10**(this.props.digit-1))); i++){
+                result.push(<StyledRulergraduation
+                                i={i}
+                                cnt={parseInt(this.props.calculatedEndTime/(10**(this.props.digit-1)))}
+                                graduation={this.calculateGraduation(i*(10**(this.props.digit-1)))}
+                                key={i}/>)
             }
             return result
         }


### PR DESCRIPTION
@wnsdud4197 
json data의 종료시간을 동적으로 계산하여 처음 보여지는 그래프의 범위를 조절합니다.
기존에는 ms 단위를 고정으로 하여, 그보다 작은 단위의 데이터에서는 처음 렌더되는 모습이 왼쪽에 작게 표시되었습니다.
이 문제를 해결하기 위해 종료시간과 그의 자릿수를 계산하여 동적으로 계산하고, 눈금과 그 단위도 그에 맞춰 표시됩니다.

**아직 해결되지 않은 과제**
확대/축소시 눈금이 생겨나거나 삭제되지 않습니다.
현재는 눈금은 너비가 0.5px인 div 태그를 띄엄띄엄 두는 것으로 그려 두었습니다.
이를 해결하기 위해서는 눈금을 자른 갯수만큼 `<div>` 태그를 너비 100%로 생성하고, 
확대된 경우(위에서 생성된 div 태그의 너비가 일정 px 보다 커진 경우) 자식을 append 하는 방식으로 구성하려고 합니다.